### PR TITLE
Add simple authentication

### DIFF
--- a/src/AareonTechnicalTest/AareonTechnicalTest.csproj
+++ b/src/AareonTechnicalTest/AareonTechnicalTest.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
+	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.13" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.11">

--- a/src/AareonTechnicalTest/Controllers/AuthController.cs
+++ b/src/AareonTechnicalTest/Controllers/AuthController.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using AareonTechnicalTest.Options;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace AareonTechnicalTest.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AuthController : ControllerBase
+    {
+        private readonly ApplicationContext dbContext;
+        private readonly IOptions<AuthConfig> authConfig;
+
+        public AuthController(ApplicationContext dbContext, IOptions<AuthConfig> authConfig)
+        {
+            this.dbContext = dbContext;
+            this.authConfig = authConfig;
+        }
+
+
+        // GET: api/<TicketController>
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> Get([FromQuery] int personId)
+        {
+            var person = await dbContext.Persons.FindAsync(personId);
+
+            if (person is null)
+            {
+                return NotFound();
+            }
+
+            var claimsList = new List<Claim>
+            {
+                new (ClaimTypes.Sid, person.Id.ToString()),
+                new (ClaimTypes.Name, $"{person.Forename} {person.Surname}"),
+            };
+
+            if (person.IsAdmin)
+            {
+                claimsList.Add(new(ClaimTypes.Role, "Admin"));
+            }
+
+            var jwtToken = new JwtSecurityToken(
+                this.authConfig.Value.Issuer,
+                this.authConfig.Value.Audience,
+                claimsList,
+                expires: DateTime.UtcNow.AddMinutes(this.authConfig.Value.AccessTokenExpiration),
+                signingCredentials: new SigningCredentials(new SymmetricSecurityKey(Encoding.ASCII.GetBytes(this.authConfig.Value.Secret)), SecurityAlgorithms.HmacSha256Signature));
+            return this.Ok(new JwtSecurityTokenHandler().WriteToken(jwtToken));
+        }
+    }
+}

--- a/src/AareonTechnicalTest/Options/AuthConfig.cs
+++ b/src/AareonTechnicalTest/Options/AuthConfig.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AareonTechnicalTest.Options
+{
+    public class AuthConfig
+    {
+        public const string Name = nameof(AuthConfig);
+
+        [Required]
+        public string Secret { get; set; }
+
+        [Required]
+        public string Issuer { get; set; }
+
+        [Required]
+        public string Audience { get; set; }
+
+        public int AccessTokenExpiration { get; set; } = 10;
+    }
+}

--- a/src/AareonTechnicalTest/Startup.cs
+++ b/src/AareonTechnicalTest/Startup.cs
@@ -1,9 +1,16 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using AareonTechnicalTest.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 
 namespace AareonTechnicalTest
@@ -23,9 +30,59 @@ namespace AareonTechnicalTest
 
             services.AddControllers();
             services.AddDbContextPool<ApplicationContext>(c => c.UseSqlite(Configuration.GetConnectionString("Default")));
+
+            services.AddOptions<AuthConfig>()
+                .Bind(Configuration.GetSection(AuthConfig.Name))
+                .ValidateDataAnnotations();
+
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(x =>
+                {
+                    var authConfig = services.BuildServiceProvider().GetRequiredService<IOptions<AuthConfig>>().Value;
+
+                    x.RequireHttpsMetadata = true;
+                    x.SaveToken = true;
+                    x.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuer = true,
+                        ValidIssuer = authConfig.Issuer,
+                        ValidateIssuerSigningKey = true,
+                        IssuerSigningKey =
+                            new SymmetricSecurityKey(
+                                Encoding.ASCII.GetBytes(authConfig.Secret)),
+                        ValidAudience = authConfig.Audience,
+                        ValidateAudience = true,
+                        ValidateLifetime = true,
+                        ClockSkew = TimeSpan.FromMinutes(1),
+                    };
+                    x.Events = new JwtBearerEvents();
+                    x.Events.OnTokenValidated += context => { return Task.CompletedTask; };
+                });
+
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "AareonTechnicalTest", Version = "v1" });
+                c.CustomSchemaIds(type => type.FullName);
+
+                var securityScheme = new OpenApiSecurityScheme
+                {
+                    Name = "JWT Authentication",
+                    Description = "Enter JWT Bearer token **_only_**",
+                    In = ParameterLocation.Header,
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer", // must be lower case
+                    BearerFormat = "JWT",
+                    Reference = new OpenApiReference
+                    {
+                        Id = JwtBearerDefaults.AuthenticationScheme,
+                        Type = ReferenceType.SecurityScheme,
+                    },
+                };
+                c.AddSecurityDefinition(securityScheme.Reference.Id, securityScheme);
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    { securityScheme, new string[] { } },
+                });
             });
         }
 
@@ -42,12 +99,12 @@ namespace AareonTechnicalTest
             app.UseHttpsRedirection();
 
             app.UseRouting();
-
+            app.UseAuthentication();
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapControllers();
+                endpoints.MapControllers().RequireAuthorization();
             });
         }
     }

--- a/src/AareonTechnicalTest/appsettings.json
+++ b/src/AareonTechnicalTest/appsettings.json
@@ -9,5 +9,11 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "Default": "Data Source=Ticketing.db"
+  },
+  "AuthConfig": {
+    "secret": "1234567890123456789",
+    "issuer": "tech-test-api",
+    "audience": "tech-test-api",
+    "accessTokenExpiration": "60" // Timeout in minutes 
   }
 }


### PR DESCRIPTION
This PR adds some simple authentication.

In order to generate a JWT token which will be used to make subsequent calls, then use the "api/auth" endpoint specifying which person you want to be impersonating.

e.g: api/auth?personId=1 for an admin user
api/auth?personId=2 for a non admin user